### PR TITLE
Fixing error in JSON output w/ OS matches

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -214,7 +214,7 @@ func startWorker(userInput string, failOnEolFound bool, eolMatchDate time.Time) 
 		var store *store.Store
 		var status *db.Status
 		var dbCloser *db.Closer
-		var sbomPackages []pkg.Package
+		var packages []pkg.Package
 		var sbom *sbom.SBOM
 		var pkgContext pkg.Context
 		var wg = &sync.WaitGroup{}
@@ -236,7 +236,7 @@ func startWorker(userInput string, failOnEolFound bool, eolMatchDate time.Time) 
 		go func() {
 			defer wg.Done()
 			log.Debugf("gathering packages")
-			sbomPackages, pkgContext, sbom, err = pkg.Provide(userInput, getProviderConfig())
+			packages, pkgContext, sbom, err = pkg.Provide(userInput, getProviderConfig())
 			if err != nil {
 				errs <- fmt.Errorf("failed to catalog: %w", err)
 				return
@@ -257,7 +257,7 @@ func startWorker(userInput string, failOnEolFound bool, eolMatchDate time.Time) 
 			Distro:   distroMatcher.MatcherConfig(appConfig.Match.Distro),
 		})
 
-		allMatches, err := xeol.FindEol(*store, pkgContext.Distro, matchers, sbomPackages, failOnEolFound, eolMatchDate)
+		allMatches, err := xeol.FindEol(*store, pkgContext.Distro, matchers, packages, failOnEolFound, eolMatchDate)
 		if err != nil {
 			errs <- err
 			if !errors.Is(err, xeolerr.ErrEolFound) {
@@ -267,7 +267,7 @@ func startWorker(userInput string, failOnEolFound bool, eolMatchDate time.Time) 
 
 		pb := models.PresenterConfig{
 			Matches:   allMatches,
-			Packages:  sbomPackages,
+			Packages:  packages,
 			SBOM:      sbom,
 			Context:   pkgContext,
 			AppConfig: appConfig,

--- a/xeol/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
+++ b/xeol/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
@@ -90,6 +90,41 @@
      "modularityLabel": ""
     }
    }
+  },
+  {
+   "Cycle": {
+    "ProductName": "Ubuntu",
+    "ReleaseCycle": "16.04",
+    "Eol": "2021-04-02",
+    "LatestRelease": "",
+    "LatestReleaseDate": "2016-07-31",
+    "ReleaseDate": "2016-07-31"
+   },
+   "Package": {
+    "ID": "",
+    "Name": "",
+    "Version": "",
+    "Locations": {},
+    "Language": "",
+    "Licenses": null,
+    "Type": "",
+    "CPEs": null,
+    "PURL": "",
+    "Upstreams": null,
+    "MetadataType": "",
+    "Metadata": null
+   },
+   "artifact": {
+    "name": "ubuntu",
+    "version": "16.04",
+    "type": "os",
+    "locations": [],
+    "language": "",
+    "licenses": [],
+    "cpes": [],
+    "purl": "",
+    "upstreams": []
+   }
   }
  ],
  "source": {

--- a/xeol/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
+++ b/xeol/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
@@ -90,6 +90,41 @@
      "modularityLabel": ""
     }
    }
+  },
+  {
+   "Cycle": {
+    "ProductName": "Ubuntu",
+    "ReleaseCycle": "16.04",
+    "Eol": "2021-04-02",
+    "LatestRelease": "",
+    "LatestReleaseDate": "2016-07-31",
+    "ReleaseDate": "2016-07-31"
+   },
+   "Package": {
+    "ID": "",
+    "Name": "",
+    "Version": "",
+    "Locations": {},
+    "Language": "",
+    "Licenses": null,
+    "Type": "",
+    "CPEs": null,
+    "PURL": "",
+    "Upstreams": null,
+    "MetadataType": "",
+    "Metadata": null
+   },
+   "artifact": {
+    "name": "ubuntu",
+    "version": "16.04",
+    "type": "os",
+    "locations": [],
+    "language": "",
+    "licenses": [],
+    "cpes": [],
+    "purl": "",
+    "upstreams": []
+   }
   }
  ],
  "source": {

--- a/xeol/presenter/models/models_helpers.go
+++ b/xeol/presenter/models/models_helpers.go
@@ -82,7 +82,6 @@ func generateMatches(t *testing.T, p, p2 pkg.Package) match.Matches {
 			Package: p,
 		},
 		{
-
 			Cycle: eol.Cycle{
 				ProductName:       "MongoDB Server",
 				ReleaseDate:       "2016-07-31",
@@ -92,6 +91,22 @@ func generateMatches(t *testing.T, p, p2 pkg.Package) match.Matches {
 				LatestReleaseDate: "2016-07-31",
 			},
 			Package: p2,
+		},
+		{
+			Cycle: eol.Cycle{
+				ProductName:       "Ubuntu",
+				ReleaseDate:       "2016-07-31",
+				ReleaseCycle:      "16.04",
+				Eol:               "2021-04-02",
+				EolBool:           false,
+				LatestReleaseDate: "2016-07-31",
+			},
+			Package: pkg.Package{
+				ID:      pkg.ID(uuid.NewString()),
+				Name:    "ubuntu",
+				Version: "16.04",
+				Type:    "os",
+			},
 		},
 	}
 

--- a/xeol/presenter/table/presenter.go
+++ b/xeol/presenter/table/presenter.go
@@ -18,14 +18,14 @@ var now = time.Now
 
 // Presenter is a generic struct for holding fields needed for reporting
 type Presenter struct {
-	results  match.Matches
+	matches  match.Matches
 	packages []pkg.Package
 }
 
 // NewPresenter is a *Presenter constructor
 func NewPresenter(pb models.PresenterConfig) *Presenter {
 	return &Presenter{
-		results:  pb.Matches,
+		matches:  pb.Matches,
 		packages: pb.Packages,
 	}
 }
@@ -36,7 +36,7 @@ func (pres *Presenter) Present(output io.Writer) error {
 
 	columns := []string{"NAME", "VERSION", "EOL", "DAYS EOL", "TYPE"}
 	// Generate rows for matches
-	for m := range pres.results.Enumerate() {
+	for m := range pres.matches.Enumerate() {
 		if m.Package.Name == "" {
 			continue
 		}

--- a/xeol/presenter/table/test-fixtures/snapshot/TestTablePresenter.golden
+++ b/xeol/presenter/table/test-fixtures/snapshot/TestTablePresenter.golden
@@ -1,3 +1,4 @@
 NAME       VERSION  EOL         DAYS EOL  TYPE 
 package-1  1.1.1    2018-07-31  1614      rpm   
 package-2  2.2.2    YES         -         deb   
+ubuntu     16.04    2021-04-02  638       os    


### PR DESCRIPTION
https://github.com/xeol-io/xeol/pull/33 introduced a bug that would cause JSON output to fail. This was reported in #60 

The reason is that the "OS" package type is not supported by Syft and was being checked against the list of packages returned from our syft ouput. We are now handling this special case separately. 

I added additional tests to catch this failure mode in the future. 