### PR TITLE
[feat] pass image name to xeol.io API

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -309,6 +309,7 @@ func startWorker(userInput string, failOnEolFound bool, eolMatchDate time.Time) 
 				Packages:  packages,
 				Context:   pkgContext,
 				AppConfig: appConfig,
+				ImageName: userInput,
 			})
 			if err := x.Send(); err != nil {
 				errs <- fmt.Errorf("failed to send eol event: %w", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -309,7 +309,7 @@ func startWorker(userInput string, failOnEolFound bool, eolMatchDate time.Time) 
 				Packages:  packages,
 				Context:   pkgContext,
 				AppConfig: appConfig,
-				ImageName: userInput,
+				ImageName: sbom.Source.ImageMetadata.UserInput,
 			})
 			if err := x.Send(); err != nil {
 				errs <- fmt.Errorf("failed to send eol event: %w", err)

--- a/xeol/report/model.go
+++ b/xeol/report/model.go
@@ -10,4 +10,5 @@ type XeolEventPayload struct {
 	Packages  []pkg.Package
 	Context   pkg.Context
 	AppConfig interface{}
+	ImageName string
 }


### PR DESCRIPTION
we are now sending along the image name to the xeol.io API when a user has an API key