### PR TITLE
[pro] Add policy enforcement

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -231,7 +231,7 @@ func isVerbose() (result bool) {
 	return appConfig.CliOptions.Verbosity > 0 || isPipedInput
 }
 
-//nolint:funlen
+//nolint:funlen,gocognit
 func startWorker(userInput string, failOnEolFound bool, eolMatchDate time.Time) <-chan error {
 	errs := make(chan error)
 	go func() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,6 +30,7 @@ import (
 	distroMatcher "github.com/xeol-io/xeol/xeol/matcher/distro"
 	pkgMatcher "github.com/xeol-io/xeol/xeol/matcher/packages"
 	"github.com/xeol-io/xeol/xeol/pkg"
+	"github.com/xeol-io/xeol/xeol/policy"
 	"github.com/xeol-io/xeol/xeol/presenter"
 	"github.com/xeol-io/xeol/xeol/presenter/models"
 	"github.com/xeol-io/xeol/xeol/report"
@@ -252,8 +253,34 @@ func startWorker(userInput string, failOnEolFound bool, eolMatchDate time.Time) 
 		var pkgContext pkg.Context
 		var wg = &sync.WaitGroup{}
 		var loadedDB, gatheredPackages bool
+		var policies []xeolio.Policy
+		x := xeolio.NewXeolClient(appConfig.APIURL, appConfig.APIKey)
 
 		wg.Add(2)
+		// wg.Add(3)
+		// go func() {
+		// 	defer wg.Done()
+		// 	log.Debug("Fetching policy")
+		// 	if appConfig.APIKey != "" && appConfig.APIURL != "" {
+		// 		policies, err = x.FetchPolicies()
+		// 		if err != nil {
+		// 			errs <- fmt.Errorf("failed to fetch policy: %w", err)
+		// 			return
+		// 		}
+		// 	}
+		// 	return
+		// }()
+
+		policies = []xeolio.Policy{
+			{
+				PolicyType:    "EOL",
+				WarnDate:      "2021-01-01",
+				DenyDate:      "2021-03-01",
+				ProductName:   "MongoDB Server",
+				Cycle:         "3.6",
+				CycleOperator: "LT",
+			},
+		}
 
 		go func() {
 			defer wg.Done()
@@ -308,19 +335,19 @@ func startWorker(userInput string, failOnEolFound bool, eolMatchDate time.Time) 
 		}
 
 		if appConfig.APIKey != "" && appConfig.APIURL != "" {
-			x := xeolio.NewXeolEvent(appConfig.APIURL, appConfig.APIKey, report.XeolEventPayload{
+			if err := x.SendEvent(report.XeolEventPayload{
 				Matches:   allMatches.Sorted(),
 				Packages:  packages,
 				Context:   pkgContext,
 				AppConfig: appConfig,
 				ImageName: sbom.Source.ImageMetadata.UserInput,
-			})
-			if err := x.Send(); err != nil {
+			}); err != nil {
 				errs <- fmt.Errorf("failed to send eol event: %w", err)
 				return
 			}
 		}
 
+		policy.Evaluate(policies, allMatches)
 		bus.Publish(partybus.Event{
 			Type:  event.EolScanningFinished,
 			Value: presenter.GetPresenter(presenterConfig, pb),

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -25,7 +25,6 @@ type defaultValueLoader interface {
 	loadDefaultValues(*viper.Viper)
 }
 
-const XeolAPIUrl = "https://engine.xeol.io/v1/scan"
 const DEFAULT_PRO_LOOKAHEAD = "now+3y"
 
 type parser interface {
@@ -47,7 +46,6 @@ type Application struct {
 	EolMatchDate           time.Time      `yaml:"-" json:"-"`
 	FailOnEolFound         bool           `yaml:"fail-on-eol-found" json:"fail-on-eol-found" mapstructure:"fail-on-eol-found"` // whether to exit with a non-zero exit code if any EOLs are found
 	APIKey                 string         `yaml:"api-key" json:"api-key" mapstructure:"api-key"`
-	APIURL                 string         `yaml:"api-url" json:"api-url" mapstructure:"api-url"`
 	ProjectName            string         `yaml:"project-name" json:"project-name" mapstructure:"project-name"`
 	ImagePath              string         `yaml:"image-path" json:"image-path" mapstructure:"image-path"`
 	Registry               registry       `yaml:"registry" json:"registry" mapstructure:"registry"`
@@ -92,7 +90,6 @@ func (cfg Application) loadDefaultValues(v *viper.Viper) {
 	v.SetDefault("check-for-app-update", true)
 	v.SetDefault("fail-on-eol-found", false)
 	v.SetDefault("project-name", getDefaultProjectName())
-	v.SetDefault("api-url", XeolAPIUrl)
 	v.SetDefault("image-path", "Dockerfile")
 	v.SetDefault("default-image-pull-source", "")
 

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -25,7 +25,7 @@ type defaultValueLoader interface {
 	loadDefaultValues(*viper.Viper)
 }
 
-const DEFAULT_PRO_LOOKAHEAD = "now+3y"
+const DefaultProLookahead = "now+3y"
 
 type parser interface {
 	parseConfigValues() error
@@ -212,7 +212,7 @@ func (cfg *Application) parseLookaheadOption() error {
 	// if the user has specified an API key and is posting results to xeol.io, then we
 	// set a default lookahead value to 3 years from now
 	if cfg.APIKey != "" {
-		cfg.EolMatchDate, err = tparse.ParseNow(time.RFC3339, DEFAULT_PRO_LOOKAHEAD)
+		cfg.EolMatchDate, err = tparse.ParseNow(time.RFC3339, DefaultProLookahead)
 		if err != nil {
 			return fmt.Errorf("bad --lookahead value: '%s'", cfg.Lookahead)
 		}

--- a/internal/ui/common_event_handlers.go
+++ b/internal/ui/common_event_handlers.go
@@ -4,10 +4,31 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/gookit/color"
 	"github.com/wagoodman/go-partybus"
 
 	xeolEventParsers "github.com/xeol-io/xeol/xeol/event/parsers"
+	"github.com/xeol-io/xeol/xeol/policy"
 )
+
+func handlePolicyEvaluationMessage(event partybus.Event, reportOutput io.Writer) error {
+	// show the report to stdout
+	pt, err := xeolEventParsers.ParsePolicyEvaluationMessage(event)
+	if err != nil {
+		return fmt.Errorf("bad %s event: %w", event.Type, err)
+	}
+
+	var message string
+	if pt.Type == policy.PolicyTypeDeny {
+		message = color.Red.Sprintf("[%s] Policy Violation: %s (v%s) needs to upgraded to a newer version. This scan will now exit non-zero.\n\n", pt.Type, pt.ProductName, pt.Cycle)
+	} else {
+		message = color.Yellow.Sprintf("[%s] Policy Violation: %s (v%s) needs to be upgraded to a newer version. This policy will fail builds starting on %s.\n\n", pt.Type, pt.ProductName, pt.Cycle, pt.FailDate)
+	}
+	if _, err := reportOutput.Write([]byte(message)); err != nil {
+		return fmt.Errorf("unable to show policy evaluation message: %w", err)
+	}
+	return nil
+}
 
 func handleEolScanningFinished(event partybus.Event, reportOutput io.Writer) error {
 	// show the report to stdout

--- a/internal/ui/ephemeral_terminal_ui.go
+++ b/internal/ui/ephemeral_terminal_ui.go
@@ -77,9 +77,12 @@ func (h *ephemeralTerminalUI) Handle(event partybus.Event) error {
 		if err := h.handler.Handle(ctx, h.frame, event, h.waitGroup); err != nil {
 			log.Errorf("unable to show %s event: %+v", event.Type, err)
 		}
-
 	case event.Type == xeolEvent.PolicyEvaluationMessage:
-		if err := handlePolicyEvaluationMessage(ctx, h.frame, event, h.waitGroup); err != nil {
+		// we need to close the screen now since signaling the the presenter is ready means that we
+		// are about to write bytes to stdout, so we should reset the terminal state first
+		h.closeScreen(false)
+
+		if err := handlePolicyEvaluationMessage(event, h.reportOutput); err != nil {
 			log.Errorf("unable to show %s event: %+v", event.Type, err)
 		}
 

--- a/internal/ui/ephemeral_terminal_ui.go
+++ b/internal/ui/ephemeral_terminal_ui.go
@@ -78,6 +78,11 @@ func (h *ephemeralTerminalUI) Handle(event partybus.Event) error {
 			log.Errorf("unable to show %s event: %+v", event.Type, err)
 		}
 
+	case event.Type == xeolEvent.PolicyEvaluationMessage:
+		if err := handlePolicyEvaluationMessage(ctx, h.frame, event, h.waitGroup); err != nil {
+			log.Errorf("unable to show %s event: %+v", event.Type, err)
+		}
+
 	case event.Type == xeolEvent.AppUpdateAvailable:
 		if err := handleAppUpdateAvailable(ctx, h.frame, event, h.waitGroup); err != nil {
 			log.Errorf("unable to show %s event: %+v", event.Type, err)

--- a/internal/ui/etui_event_handlers.go
+++ b/internal/ui/etui_event_handlers.go
@@ -16,7 +16,6 @@ import (
 	"github.com/xeol-io/xeol/internal"
 	"github.com/xeol-io/xeol/internal/version"
 	xeolEventParsers "github.com/xeol-io/xeol/xeol/event/parsers"
-	"github.com/xeol-io/xeol/xeol/policy"
 )
 
 func handleAppUpdateAvailable(_ context.Context, fr *frame.Frame, event partybus.Event, _ *sync.WaitGroup) error {
@@ -33,25 +32,5 @@ func handleAppUpdateAvailable(_ context.Context, fr *frame.Frame, event partybus
 	message := color.Magenta.Sprintf("New version of %s is available: %s (currently running: %s)", internal.ApplicationName, newVersion, version.FromBuild().Version)
 	_, _ = io.WriteString(line, message)
 
-	return nil
-}
-
-func handlePolicyEvaluationMessage(_ context.Context, fr *frame.Frame, event partybus.Event, _ *sync.WaitGroup) error {
-	pt, err := xeolEventParsers.ParsePolicyEvaluationMessage(event)
-	if err != nil {
-		return fmt.Errorf("bad %s event: %w", event.Type, err)
-	}
-
-	line, err := fr.Append()
-	if err != nil {
-		return err
-	}
-	var message string
-	if pt.Type == policy.PolicyTypeDeny {
-		message = color.Red.Sprintf("[%s] Policy Violation: %s (v%s) needs to upgraded to a newer version. This scan will now exit non-zero.", pt.Type, pt.ProductName, pt.Cycle)
-	} else {
-		message = color.Yellow.Sprintf("[%s] Policy Violation: %s (v%s) needs to be upgraded to a newer version. This policy will fail builds starting on %s.", pt.Type, pt.ProductName, pt.Cycle, pt.FailDate)
-	}
-	_, _ = io.WriteString(line, message)
 	return nil
 }

--- a/internal/ui/etui_event_handlers.go
+++ b/internal/ui/etui_event_handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/xeol-io/xeol/internal"
 	"github.com/xeol-io/xeol/internal/version"
 	xeolEventParsers "github.com/xeol-io/xeol/xeol/event/parsers"
+	"github.com/xeol-io/xeol/xeol/policy"
 )
 
 func handleAppUpdateAvailable(_ context.Context, fr *frame.Frame, event partybus.Event, _ *sync.WaitGroup) error {
@@ -32,5 +33,25 @@ func handleAppUpdateAvailable(_ context.Context, fr *frame.Frame, event partybus
 	message := color.Magenta.Sprintf("New version of %s is available: %s (currently running: %s)", internal.ApplicationName, newVersion, version.FromBuild().Version)
 	_, _ = io.WriteString(line, message)
 
+	return nil
+}
+
+func handlePolicyEvaluationMessage(_ context.Context, fr *frame.Frame, event partybus.Event, _ *sync.WaitGroup) error {
+	pt, err := xeolEventParsers.ParsePolicyEvaluationMessage(event)
+	if err != nil {
+		return fmt.Errorf("bad %s event: %w", event.Type, err)
+	}
+
+	line, err := fr.Append()
+	if err != nil {
+		return err
+	}
+	var message string
+	if pt.Type == policy.PolicyTypeDeny {
+		message = color.Red.Sprintf("[%s] Policy Violation: %s (v%s) needs to upgraded to a newer version. This scan will now exit non-zero.", pt.Type, pt.ProductName, pt.Cycle)
+	} else {
+		message = color.Yellow.Sprintf("[%s] Policy Violation: %s (v%s) needs to be upgraded to a newer version. This policy will fail builds starting on %s.", pt.Type, pt.ProductName, pt.Cycle, pt.FailDate)
+	}
+	_, _ = io.WriteString(line, message)
 	return nil
 }

--- a/internal/ui/logger_ui.go
+++ b/internal/ui/logger_ui.go
@@ -28,6 +28,10 @@ func (l *loggerUI) Setup(unsubscribe func() error) error {
 
 func (l loggerUI) Handle(event partybus.Event) error {
 	switch event.Type {
+	case xeolEvent.PolicyEvaluationMessage:
+		if err := handlePolicyEvaluationMessage(event, l.reportOutput); err != nil {
+			log.Warnf("unable to show policy evaluation message event: %+v", err)
+		}
 	case xeolEvent.EolScanningFinished:
 		if err := handleEolScanningFinished(event, l.reportOutput); err != nil {
 			log.Warnf("unable to show catalog image finished event: %+v", err)

--- a/internal/xeolio/request.go
+++ b/internal/xeolio/request.go
@@ -17,8 +17,8 @@ type PolicyType string
 type CycleOperator string
 
 const (
-	XeolAPIUrl    = "https://api.xeol.io"
-	XeolEngineUrl = "https://engine.xeol.io"
+	XeolAPIURL    = "https://api.xeol.io"
+	XeolEngineURL = "https://engine.xeol.io"
 
 	PolicyTypeEol PolicyType = "EOL"
 
@@ -28,7 +28,7 @@ const (
 )
 
 type Policy struct {
-	Id            string        `json:"id"`
+	ID            string        `json:"id"`
 	PolicyType    PolicyType    `json:"policy_type"`
 	WarnDate      string        `json:"warn_date"`
 	DenyDate      string        `json:"deny_date"`
@@ -102,7 +102,7 @@ func (x *XeolClient) makeRequest(method, url, path string, body io.Reader, out i
 
 func (x *XeolClient) FetchPolicies() ([]Policy, error) {
 	var policies []Policy
-	err := x.makeRequest("GET", XeolAPIUrl, "v1/policy", nil, &policies)
+	err := x.makeRequest("GET", XeolAPIURL, "v1/policy", nil, &policies)
 	if err != nil {
 		return nil, err
 	}
@@ -116,5 +116,5 @@ func (x *XeolClient) SendEvent(payload report.XeolEventPayload) error {
 		return fmt.Errorf("error marshalling xeol.io API request: %v", err)
 	}
 
-	return x.makeRequest("PUT", XeolEngineUrl, "v1/scan", bytes.NewBuffer(p), nil)
+	return x.makeRequest("PUT", XeolEngineURL, "v1/scan", bytes.NewBuffer(p), nil)
 }

--- a/internal/xeolio/request.go
+++ b/internal/xeolio/request.go
@@ -4,26 +4,70 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/xeol-io/xeol/internal/log"
 	"github.com/xeol-io/xeol/xeol/report"
 )
 
-type XeolEvent struct {
-	URL     string
-	APIKey  string
-	Payload report.XeolEventPayload
+type PolicyType string
+type CycleOperator string
+
+const (
+	PolicyTypeEol PolicyType = "EOL"
+
+	CycleOperatorLessThan        CycleOperator = "LT"
+	CycleOperatorLessThanOrEqual CycleOperator = "LTE"
+	CycleOperatorEqual           CycleOperator = "EQ"
+)
+
+type Policy struct {
+	Id            string        `json:"id"`
+	PolicyType    PolicyType    `json:"policy_type"`
+	WarnDate      string        `json:"warn_date"`
+	DenyDate      string        `json:"deny_date"`
+	ProductName   string        `json:"product_name"`
+	Cycle         string        `json:"cycle"`
+	CycleOperator CycleOperator `json:"cycle_operator"`
 }
 
-func (x *XeolEvent) Send() error {
-	payload, err := json.Marshal(x.Payload)
-	if err != nil {
-		return fmt.Errorf("error marshalling xeol.io API request: %v", err)
+func (pt *PolicyType) UnmarshalJSON(b []byte) error {
+	str := strings.Trim(string(b), "\"")
+	if str != string(PolicyTypeEol) {
+		return fmt.Errorf("invalid PolicyType %s", str)
 	}
+	*pt = PolicyType(str)
+	return nil
+}
 
-	req, err := http.NewRequest("PUT", x.URL, bytes.NewBuffer(payload))
+func (co *CycleOperator) UnmarshalJSON(b []byte) error {
+	str := strings.Trim(string(b), "\"")
+	switch str {
+	case string(CycleOperatorLessThan), string(CycleOperatorLessThanOrEqual), string(CycleOperatorEqual):
+		*co = CycleOperator(str)
+	default:
+		return fmt.Errorf("invalid CycleOperator %s", str)
+	}
+	return nil
+}
+
+type XeolClient struct {
+	URL    string
+	APIKey string
+}
+
+func NewXeolClient(url string, apiKey string) *XeolClient {
+	return &XeolClient{
+		URL:    url,
+		APIKey: apiKey,
+	}
+}
+
+func (x *XeolClient) makeRequest(method, path string, body io.Reader, out interface{}) error {
+	req, err := http.NewRequest(method, fmt.Sprintf("%s/%s", x.URL, path), body)
 	if err != nil {
 		return err
 	}
@@ -38,20 +82,38 @@ func (x *XeolEvent) Send() error {
 	if err != nil {
 		return fmt.Errorf("xeol.io API request failed: %v", err)
 	}
-
 	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("xeol.io API unexpected status code %d", resp.StatusCode)
 	}
 
-	log.Debug("sent event to xeol.io API at %s", x.URL)
+	if out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return fmt.Errorf("xeol.io API response decode failed: %v", err)
+		}
+	} else {
+		log.Debug("sent event to xeol.io API at %s", req.URL.String())
+	}
+
 	return nil
 }
 
-func NewXeolEvent(url string, apiKey string, payload report.XeolEventPayload) *XeolEvent {
-	return &XeolEvent{
-		URL:     url,
-		APIKey:  apiKey,
-		Payload: payload,
+func (x *XeolClient) FetchPolicies() ([]Policy, error) {
+	var policies []Policy
+	err := x.makeRequest("GET", "v1/policies", nil, &policies)
+	if err != nil {
+		return nil, err
 	}
+
+	return policies, nil
+}
+
+func (x *XeolClient) SendEvent(payload report.XeolEventPayload) error {
+	p, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("error marshalling xeol.io API request: %v", err)
+	}
+
+	return x.makeRequest("PUT", "v1/events", bytes.NewBuffer(p), nil)
 }

--- a/internal/xeolio/request.go
+++ b/internal/xeolio/request.go
@@ -17,6 +17,9 @@ type PolicyType string
 type CycleOperator string
 
 const (
+	XeolAPIUrl    = "https://api.xeol.io"
+	XeolEngineUrl = "https://engine.xeol.io"
+
 	PolicyTypeEol PolicyType = "EOL"
 
 	CycleOperatorLessThan        CycleOperator = "LT"
@@ -55,19 +58,17 @@ func (co *CycleOperator) UnmarshalJSON(b []byte) error {
 }
 
 type XeolClient struct {
-	URL    string
 	APIKey string
 }
 
-func NewXeolClient(url string, apiKey string) *XeolClient {
+func NewXeolClient(apiKey string) *XeolClient {
 	return &XeolClient{
-		URL:    url,
 		APIKey: apiKey,
 	}
 }
 
-func (x *XeolClient) makeRequest(method, path string, body io.Reader, out interface{}) error {
-	req, err := http.NewRequest(method, fmt.Sprintf("%s/%s", x.URL, path), body)
+func (x *XeolClient) makeRequest(method, url, path string, body io.Reader, out interface{}) error {
+	req, err := http.NewRequest(method, fmt.Sprintf("%s/%s", url, path), body)
 	if err != nil {
 		return err
 	}
@@ -101,7 +102,7 @@ func (x *XeolClient) makeRequest(method, path string, body io.Reader, out interf
 
 func (x *XeolClient) FetchPolicies() ([]Policy, error) {
 	var policies []Policy
-	err := x.makeRequest("GET", "v1/policies", nil, &policies)
+	err := x.makeRequest("GET", XeolAPIUrl, "v1/policy", nil, &policies)
 	if err != nil {
 		return nil, err
 	}
@@ -115,5 +116,5 @@ func (x *XeolClient) SendEvent(payload report.XeolEventPayload) error {
 		return fmt.Errorf("error marshalling xeol.io API request: %v", err)
 	}
 
-	return x.makeRequest("PUT", "v1/events", bytes.NewBuffer(p), nil)
+	return x.makeRequest("PUT", XeolEngineUrl, "v1/scan", bytes.NewBuffer(p), nil)
 }

--- a/xeol/event/event.go
+++ b/xeol/event/event.go
@@ -7,6 +7,7 @@ const (
 	UpdateEolDatabase              partybus.EventType = "xeol-update-eol-database"
 	EolScanningStarted             partybus.EventType = "xeol-eol-scanning-started"
 	EolScanningFinished            partybus.EventType = "xeol-eol-scanning-finished"
+	PolicyEvaluationMessage        partybus.EventType = "xeol-policy-evaluation-message"
 	AttestationVerified            partybus.EventType = "xeol-attestation-signature-passed"
 	AttestationVerificationSkipped partybus.EventType = "xeol-attestation-verification-skipped"
 	NonRootCommandFinished         partybus.EventType = "xeol-non-root-command-finished"

--- a/xeol/event/parsers/parsers.go
+++ b/xeol/event/parsers/parsers.go
@@ -37,12 +37,12 @@ func checkEventType(actual, expected partybus.EventType) error {
 	return nil
 }
 
-func ParsePolicyEvaluationMessage(e partybus.Event) (*policy.PolicyEvaluationResult, error) {
+func ParsePolicyEvaluationMessage(e partybus.Event) (*policy.EvaluationResult, error) {
 	if err := checkEventType(e.Type, event.PolicyEvaluationMessage); err != nil {
 		return nil, err
 	}
 
-	pt, ok := e.Value.(policy.PolicyEvaluationResult)
+	pt, ok := e.Value.(policy.EvaluationResult)
 	if !ok {
 		return nil, newPayloadErr(e.Type, "Value", e.Value)
 	}

--- a/xeol/event/parsers/parsers.go
+++ b/xeol/event/parsers/parsers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/xeol-io/xeol/xeol/event"
 	"github.com/xeol-io/xeol/xeol/matcher"
+	"github.com/xeol-io/xeol/xeol/policy"
 	"github.com/xeol-io/xeol/xeol/presenter"
 )
 
@@ -34,6 +35,18 @@ func checkEventType(actual, expected partybus.EventType) error {
 		return newPayloadErr(expected, "Type", actual)
 	}
 	return nil
+}
+
+func ParsePolicyEvaluationMessage(e partybus.Event) (*policy.PolicyEvaluationResult, error) {
+	if err := checkEventType(e.Type, event.PolicyEvaluationMessage); err != nil {
+		return nil, err
+	}
+
+	pt, ok := e.Value.(policy.PolicyEvaluationResult)
+	if !ok {
+		return nil, newPayloadErr(e.Type, "Value", e.Value)
+	}
+	return &pt, nil
 }
 
 func ParseAppUpdateAvailable(e partybus.Event) (string, error) {

--- a/xeol/policy/policy.go
+++ b/xeol/policy/policy.go
@@ -3,28 +3,28 @@ package policy
 import (
 	"time"
 
+	"github.com/Masterminds/semver"
 	"github.com/wagoodman/go-partybus"
+
 	"github.com/xeol-io/xeol/internal/bus"
 	"github.com/xeol-io/xeol/internal/log"
-
-	"github.com/Masterminds/semver"
 	"github.com/xeol-io/xeol/internal/xeolio"
 	"github.com/xeol-io/xeol/xeol/event"
 	"github.com/xeol-io/xeol/xeol/match"
 )
 
 const (
-	DateLayout                          = "2006-01-02"
-	PolicyTypeWarn PolicyEvaluationType = "WARN"
-	PolicyTypeDeny PolicyEvaluationType = "DENY"
+	DateLayout                    = "2006-01-02"
+	PolicyTypeWarn EvaluationType = "WARN"
+	PolicyTypeDeny EvaluationType = "DENY"
 )
 
 var timeNow = time.Now
 
-type PolicyEvaluationType string
+type EvaluationType string
 
-type PolicyEvaluationResult struct {
-	Type        PolicyEvaluationType
+type EvaluationResult struct {
+	Type        EvaluationType
 	ProductName string
 	Cycle       string
 	FailDate    string
@@ -84,13 +84,13 @@ func denyMatch(policy xeolio.Policy) bool {
 	return false
 }
 
-func evaluateMatches(policies []xeolio.Policy, matches match.Matches) []PolicyEvaluationResult {
-	var results []PolicyEvaluationResult
+func evaluateMatches(policies []xeolio.Policy, matches match.Matches) []EvaluationResult {
+	var results []EvaluationResult
 	for _, policy := range policies {
 		for _, match := range matches.Sorted() {
 			if cycleOperatorMatch(match, policy) {
 				if denyMatch(policy) {
-					results = append(results, PolicyEvaluationResult{
+					results = append(results, EvaluationResult{
 						Type:        PolicyTypeDeny,
 						ProductName: match.Cycle.ProductName,
 						Cycle:       match.Cycle.ReleaseCycle,
@@ -99,7 +99,7 @@ func evaluateMatches(policies []xeolio.Policy, matches match.Matches) []PolicyEv
 					continue
 				}
 				if warnMatch(policy) {
-					results = append(results, PolicyEvaluationResult{
+					results = append(results, EvaluationResult{
 						Type:        PolicyTypeWarn,
 						ProductName: match.Cycle.ProductName,
 						Cycle:       match.Cycle.ReleaseCycle,

--- a/xeol/policy/policy.go
+++ b/xeol/policy/policy.go
@@ -115,13 +115,19 @@ func evaluateMatches(policies []xeolio.Policy, matches match.Matches) []PolicyEv
 }
 
 // Evaluate evaluates a set of policies against a set of matches.
-func Evaluate(policies []xeolio.Policy, matches match.Matches) error {
+func Evaluate(policies []xeolio.Policy, matches match.Matches) bool {
 	policyMatches := evaluateMatches(policies, matches)
+	// whether we should fail the scan or not
+	failScan := false
+
 	for _, policyMatch := range policyMatches {
+		if policyMatch.Type == PolicyTypeDeny {
+			failScan = true
+		}
 		bus.Publish(partybus.Event{
 			Type:  event.PolicyEvaluationMessage,
 			Value: policyMatch,
 		})
 	}
-	return nil
+	return failScan
 }

--- a/xeol/policy/policy.go
+++ b/xeol/policy/policy.go
@@ -1,0 +1,117 @@
+package policy
+
+import (
+	"time"
+
+	"github.com/wagoodman/go-partybus"
+	"github.com/xeol-io/xeol/internal/bus"
+	"github.com/xeol-io/xeol/internal/log"
+
+	"github.com/Masterminds/semver"
+	"github.com/xeol-io/xeol/internal/xeolio"
+	"github.com/xeol-io/xeol/xeol/event"
+	"github.com/xeol-io/xeol/xeol/match"
+)
+
+const (
+	DateLayout                          = "2006-01-02"
+	PolicyTypeWarn PolicyEvaluationType = "WARN"
+	PolicyTypeDeny PolicyEvaluationType = "DENY"
+)
+
+type PolicyEvaluationType string
+
+type PolicyEvaluationResult struct {
+	Type        PolicyEvaluationType
+	ProductName string
+	Cycle       string
+	FailDate    string
+}
+
+func cycleOperatorMatch(m match.Match, policy xeolio.Policy) bool {
+	if m.Cycle.ProductName != policy.ProductName {
+		return false
+	}
+
+	pv, err := semver.NewVersion(policy.Cycle)
+	if err != nil {
+		log.Debugf("Invalid policy cycle version: %s", policy.Cycle)
+		return false
+	}
+
+	mv, err := semver.NewVersion(m.Cycle.ReleaseCycle)
+	if err != nil {
+		log.Debugf("Invalid match cycle version: %s", m.Cycle.ReleaseCycle)
+		return false
+	}
+
+	switch policy.CycleOperator {
+	case xeolio.CycleOperatorLessThan:
+		return mv.LessThan(pv)
+	case xeolio.CycleOperatorLessThanOrEqual:
+		return !mv.GreaterThan(pv) // equivalent to mv <= pv
+	case xeolio.CycleOperatorEqual:
+		return mv.Equal(pv)
+	default:
+		log.Debugf("Invalid policy cycle operator: %s", policy.CycleOperator)
+		return false
+	}
+}
+
+func warnMatch(policy xeolio.Policy) bool {
+	warnDate, err := time.Parse(DateLayout, policy.WarnDate)
+	if err != nil {
+		log.Debugf("Invalid policy warn date: %s", policy.WarnDate)
+		return false
+	}
+	if time.Now().After(warnDate) {
+		return true
+	}
+	return false
+}
+
+func denyMatch(policy xeolio.Policy) bool {
+	denyDate, err := time.Parse(DateLayout, policy.DenyDate)
+	if err != nil {
+		log.Debugf("Invalid policy deny date: %s", policy.DenyDate)
+		return false
+	}
+	if time.Now().After(denyDate) {
+		return true
+	}
+	return false
+}
+
+// Evaluate evaluates a set of policies against a set of matches.
+func Evaluate(policies []xeolio.Policy, matches match.Matches) error {
+	for _, policy := range policies {
+		for _, match := range matches.Sorted() {
+			if cycleOperatorMatch(match, policy) {
+				if denyMatch(policy) {
+					bus.Publish(partybus.Event{
+						Type: event.PolicyEvaluationMessage,
+						Value: PolicyEvaluationResult{
+							Type:        PolicyTypeDeny,
+							ProductName: match.Cycle.ProductName,
+							Cycle:       match.Cycle.ReleaseCycle,
+						},
+					})
+					continue
+				}
+				if warnMatch(policy) {
+					bus.Publish(partybus.Event{
+						Type: event.PolicyEvaluationMessage,
+						Value: PolicyEvaluationResult{
+							Type:        PolicyTypeWarn,
+							ProductName: match.Cycle.ProductName,
+							Cycle:       match.Cycle.ReleaseCycle,
+							FailDate:    policy.DenyDate,
+						},
+					})
+					continue
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/xeol/policy/policy_test.go
+++ b/xeol/policy/policy_test.go
@@ -7,6 +7,7 @@ import (
 
 	syftPkg "github.com/anchore/syft/syft/pkg"
 	"github.com/google/uuid"
+
 	"github.com/xeol-io/xeol/internal/xeolio"
 	"github.com/xeol-io/xeol/xeol/eol"
 	"github.com/xeol-io/xeol/xeol/match"
@@ -18,7 +19,7 @@ func TestEvaluate(t *testing.T) {
 		name    string
 		policy  []xeolio.Policy
 		matches []match.Match
-		want    []PolicyEvaluationResult
+		want    []EvaluationResult
 	}{
 		{
 			name: "policy with no matches",
@@ -72,7 +73,7 @@ func TestEvaluate(t *testing.T) {
 					},
 				},
 			},
-			want: []PolicyEvaluationResult{
+			want: []EvaluationResult{
 				{
 					Type:        PolicyTypeDeny,
 					ProductName: "foo",
@@ -105,7 +106,7 @@ func TestEvaluate(t *testing.T) {
 					},
 				},
 			},
-			want: []PolicyEvaluationResult{
+			want: []EvaluationResult{
 				{
 					Type:        PolicyTypeWarn,
 					ProductName: "foo",
@@ -139,7 +140,7 @@ func TestEvaluate(t *testing.T) {
 					},
 				},
 			},
-			want: []PolicyEvaluationResult{
+			want: []EvaluationResult{
 				{
 					Type:        PolicyTypeWarn,
 					ProductName: "foo",
@@ -173,7 +174,7 @@ func TestEvaluate(t *testing.T) {
 					},
 				},
 			},
-			want: []PolicyEvaluationResult{
+			want: []EvaluationResult{
 				{
 					Type:        PolicyTypeWarn,
 					ProductName: "foo",
@@ -226,7 +227,7 @@ func TestEvaluate(t *testing.T) {
 					},
 				},
 			},
-			want: []PolicyEvaluationResult{
+			want: []EvaluationResult{
 				{
 					Type:        PolicyTypeWarn,
 					ProductName: "foo",

--- a/xeol/policy/policy_test.go
+++ b/xeol/policy/policy_test.go
@@ -1,0 +1,342 @@
+package policy
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	syftPkg "github.com/anchore/syft/syft/pkg"
+	"github.com/google/uuid"
+	"github.com/xeol-io/xeol/internal/xeolio"
+	"github.com/xeol-io/xeol/xeol/eol"
+	"github.com/xeol-io/xeol/xeol/match"
+	"github.com/xeol-io/xeol/xeol/pkg"
+)
+
+func TestEvaluate(t *testing.T) {
+	tests := []struct {
+		name    string
+		policy  []xeolio.Policy
+		matches []match.Match
+		want    []PolicyEvaluationResult
+	}{
+		{
+			name: "policy with no matches",
+			policy: []xeolio.Policy{
+				{
+					ProductName:   "foo",
+					Cycle:         "1.0.0",
+					CycleOperator: xeolio.CycleOperatorLessThan,
+					WarnDate:      "2021-01-01",
+					DenyDate:      "2021-01-01",
+				},
+			},
+			matches: []match.Match{
+				{
+					Cycle: eol.Cycle{
+						ProductName:  "product-e",
+						ReleaseCycle: "1.0.0",
+					},
+					Package: pkg.Package{
+						ID:      pkg.ID(uuid.NewString()),
+						Name:    "package-e",
+						Version: "2.0.0",
+						Type:    syftPkg.RpmPkg,
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "policy with deny match",
+			policy: []xeolio.Policy{
+				{
+					ProductName:   "foo",
+					Cycle:         "1.0",
+					CycleOperator: xeolio.CycleOperatorLessThanOrEqual,
+					WarnDate:      "2021-01-01",
+					DenyDate:      "2021-01-29",
+				},
+			},
+			matches: []match.Match{
+				{
+					Cycle: eol.Cycle{
+						ProductName:  "foo",
+						ReleaseCycle: "1.0",
+					},
+					Package: pkg.Package{
+						ID:      pkg.ID(uuid.NewString()),
+						Name:    "foo",
+						Version: "1.2.1",
+						Type:    syftPkg.RpmPkg,
+					},
+				},
+			},
+			want: []PolicyEvaluationResult{
+				{
+					Type:        PolicyTypeDeny,
+					ProductName: "foo",
+					Cycle:       "1.0",
+				},
+			},
+		},
+		{
+			name: "policy with warn match, version less than equal",
+			policy: []xeolio.Policy{
+				{
+					ProductName:   "foo",
+					Cycle:         "1.0",
+					CycleOperator: xeolio.CycleOperatorLessThanOrEqual,
+					WarnDate:      "2021-01-01",
+					DenyDate:      "2021-03-01",
+				},
+			},
+			matches: []match.Match{
+				{
+					Cycle: eol.Cycle{
+						ProductName:  "foo",
+						ReleaseCycle: "1.0",
+					},
+					Package: pkg.Package{
+						ID:      pkg.ID(uuid.NewString()),
+						Name:    "foo",
+						Version: "1.2.1",
+						Type:    syftPkg.RpmPkg,
+					},
+				},
+			},
+			want: []PolicyEvaluationResult{
+				{
+					Type:        PolicyTypeWarn,
+					ProductName: "foo",
+					Cycle:       "1.0",
+					FailDate:    "2021-03-01",
+				},
+			},
+		},
+		{
+			name: "policy with warn match, version less than",
+			policy: []xeolio.Policy{
+				{
+					ProductName:   "foo",
+					Cycle:         "1.0",
+					CycleOperator: xeolio.CycleOperatorLessThan,
+					WarnDate:      "2021-01-01",
+					DenyDate:      "2021-03-01",
+				},
+			},
+			matches: []match.Match{
+				{
+					Cycle: eol.Cycle{
+						ProductName:  "foo",
+						ReleaseCycle: "0.9",
+					},
+					Package: pkg.Package{
+						ID:      pkg.ID(uuid.NewString()),
+						Name:    "foo",
+						Version: "0.9.0",
+						Type:    syftPkg.RpmPkg,
+					},
+				},
+			},
+			want: []PolicyEvaluationResult{
+				{
+					Type:        PolicyTypeWarn,
+					ProductName: "foo",
+					Cycle:       "0.9",
+					FailDate:    "2021-03-01",
+				},
+			},
+		},
+		{
+			name: "policy with warn match, version equal",
+			policy: []xeolio.Policy{
+				{
+					ProductName:   "foo",
+					Cycle:         "1.0",
+					CycleOperator: xeolio.CycleOperatorEqual,
+					WarnDate:      "2021-01-01",
+					DenyDate:      "2021-03-01",
+				},
+			},
+			matches: []match.Match{
+				{
+					Cycle: eol.Cycle{
+						ProductName:  "foo",
+						ReleaseCycle: "1.0",
+					},
+					Package: pkg.Package{
+						ID:      pkg.ID(uuid.NewString()),
+						Name:    "foo",
+						Version: "1.0.1",
+						Type:    syftPkg.RpmPkg,
+					},
+				},
+			},
+			want: []PolicyEvaluationResult{
+				{
+					Type:        PolicyTypeWarn,
+					ProductName: "foo",
+					Cycle:       "1.0",
+					FailDate:    "2021-03-01",
+				},
+			},
+		},
+		{
+			name: "test multiple policy matches",
+			policy: []xeolio.Policy{
+				{
+					ProductName:   "foo",
+					Cycle:         "1.3",
+					CycleOperator: xeolio.CycleOperatorEqual,
+					WarnDate:      "2021-01-01",
+					DenyDate:      "2021-03-01",
+				},
+				{
+					ProductName:   "bar",
+					Cycle:         "2.1",
+					CycleOperator: xeolio.CycleOperatorLessThanOrEqual,
+					WarnDate:      "2021-01-01",
+					DenyDate:      "2021-01-29",
+				},
+			},
+			matches: []match.Match{
+				{
+					Cycle: eol.Cycle{
+						ProductName:  "foo",
+						ReleaseCycle: "1.3",
+					},
+					Package: pkg.Package{
+						ID:      pkg.ID(uuid.NewString()),
+						Name:    "foo",
+						Version: "1.3.0",
+						Type:    syftPkg.RpmPkg,
+					},
+				},
+				{
+					Cycle: eol.Cycle{
+						ProductName:  "bar",
+						ReleaseCycle: "2.0",
+					},
+					Package: pkg.Package{
+						ID:      pkg.ID(uuid.NewString()),
+						Name:    "bar",
+						Version: "2.0.1",
+						Type:    syftPkg.RpmPkg,
+					},
+				},
+			},
+			want: []PolicyEvaluationResult{
+				{
+					Type:        PolicyTypeWarn,
+					ProductName: "foo",
+					Cycle:       "1.3",
+					FailDate:    "2021-03-01",
+				},
+				{
+					Type:        PolicyTypeDeny,
+					ProductName: "bar",
+					Cycle:       "2.0",
+				},
+			},
+		},
+		{
+			name: "test bad dates",
+			policy: []xeolio.Policy{
+				{
+					ProductName:   "foo",
+					Cycle:         "1.3",
+					CycleOperator: xeolio.CycleOperatorEqual,
+					WarnDate:      "2021/01/01",
+					DenyDate:      "2021/03/01",
+				},
+			},
+			matches: []match.Match{
+				{
+					Cycle: eol.Cycle{
+						ProductName:  "foo",
+						ReleaseCycle: "1.3",
+					},
+					Package: pkg.Package{
+						ID:      pkg.ID(uuid.NewString()),
+						Name:    "foo",
+						Version: "1.3.0",
+						Type:    syftPkg.RpmPkg,
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "test bad cycles",
+			policy: []xeolio.Policy{
+				{
+					ProductName:   "foo",
+					Cycle:         "1.4",
+					CycleOperator: xeolio.CycleOperatorEqual,
+					WarnDate:      "2021/01/01",
+					DenyDate:      "2021/03/01",
+				},
+			},
+			matches: []match.Match{
+				{
+					Cycle: eol.Cycle{
+						ProductName:  "foo",
+						ReleaseCycle: "1.3",
+					},
+					Package: pkg.Package{
+						ID:      pkg.ID(uuid.NewString()),
+						Name:    "foo",
+						Version: "1.3.0",
+						Type:    syftPkg.RpmPkg,
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "test future dates",
+			policy: []xeolio.Policy{
+				{
+					ProductName:   "foo",
+					Cycle:         "1.3",
+					CycleOperator: xeolio.CycleOperatorEqual,
+					WarnDate:      "2021-04-01",
+					DenyDate:      "2021-05-01",
+				},
+			},
+			matches: []match.Match{
+				{
+					Cycle: eol.Cycle{
+						ProductName:  "foo",
+						ReleaseCycle: "1.3",
+					},
+					Package: pkg.Package{
+						ID:      pkg.ID(uuid.NewString()),
+						Name:    "foo",
+						Version: "1.3.0",
+						Type:    syftPkg.RpmPkg,
+					},
+				},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			timeNow = func() time.Time {
+				return time.Date(2021, 2, 1, 0, 0, 0, 0, time.UTC)
+			}
+
+			matches := match.NewMatches(tt.matches...)
+			policyMatches := evaluateMatches(tt.policy, matches)
+			if len(policyMatches) != len(tt.want) {
+				t.Errorf("expected %d policy matches, got %d", len(tt.want), len(policyMatches))
+			}
+			if !reflect.DeepEqual(policyMatches, tt.want) {
+				t.Errorf("expected policy matches to be %v, got %v", tt.want, policyMatches)
+			}
+		})
+	}
+}

--- a/xeol/search/purl.go
+++ b/xeol/search/purl.go
@@ -68,6 +68,8 @@ func ByDistroCpe(store eol.Provider, distro *linux.Release, eolMatchDate time.Ti
 	return match.Match{}, nil
 }
 
+// returnMatchingCycle returns the first cycle that matches the version string.
+// If no cycle matches, an empty cycle is returned.
 func returnMatchingCycle(version string, cycles []eol.Cycle) (eol.Cycle, error) {
 	v, err := semver.NewVersion(version)
 	if err != nil {

--- a/xeol/xeolerr/errors.go
+++ b/xeol/xeolerr/errors.go
@@ -3,4 +3,6 @@ package xeolerr
 var (
 	// ErrEolFound indicates when an EOL package is found and --fail-on-eol-found is set
 	ErrEolFound = NewExpectedErr("discovered EOL packages")
+	// ErrPolicyViolation indicates when a policy violation has occurred
+	ErrPolicyViolation = NewExpectedErr("policy violation")
 )


### PR DESCRIPTION
Add policy enforcement of scans using the xeol api. This will fail xeol scans based on the policies defined in the xeol.io dashboard.