### PR TITLE
[bug] show failscan error after results

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -335,15 +335,16 @@ func startWorker(userInput string, failOnEolFound bool, eolMatchDate time.Time) 
 		}
 
 		failScan := policy.Evaluate(policies, allMatches)
-		if failScan {
-			errs <- xeolerr.ErrPolicyViolation
-			return
-		}
 
 		bus.Publish(partybus.Event{
 			Type:  event.EolScanningFinished,
 			Value: presenter.GetPresenter(presenterConfig, pb),
 		})
+
+		if failScan {
+			errs <- xeolerr.ErrPolicyViolation
+			return
+		}
 	}()
 	return errs
 }


### PR DESCRIPTION
this is what the policy fail output looks like now, missing the EOL results

```
 ✔ EOL DB                  [no update available]
 ✔ Loaded image
 ✔ Parsed image
 ✔ Cataloged packages      [112 packages]
 ✔ Scanned image           [1 eol]
[DENY] Policy Violation: MongoDB Server (v3.2) needs to upgraded to a newer version. This scan will now exit non-zero.

1 error occurred:
	* policy violation

exit status 1
```

this is what this PR changes it to 

```
 ✔ EOL DB                  [no update available]
 ✔ Loaded image
 ✔ Parsed image
 ✔ Cataloged packages      [112 packages]
 ✔ Scanned image           [1 eol]

[DENY] Policy Violation: MongoDB Server (v3.2) needs to upgraded to a newer version. This scan will now exit non-zero.

NAME                VERSION  EOL         DAYS EOL  TYPE
Debian GNU/Linux    8        2018-06-17  1855      os
mongodb-org-server  3.2.21   2018-07-31  1811      deb
1 error occurred:
	* policy violation

exit status 1
```