### PR TITLE
Send SBOM w/ xeol.io event

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/xeol-io/xeol
 go 1.18
 
 require (
+	github.com/CycloneDX/cyclonedx-go v0.7.1
 	github.com/Masterminds/semver v1.5.0
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/adrg/xdg v0.4.0
@@ -56,7 +57,6 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v0.13.0 // indirect
 	cloud.google.com/go/storage v1.28.1 // indirect
-	github.com/CycloneDX/cyclonedx-go v0.7.1 // indirect
 	github.com/DataDog/zstd v1.4.5 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect

--- a/xeol/report/model.go
+++ b/xeol/report/model.go
@@ -11,4 +11,5 @@ type XeolEventPayload struct {
 	Context   pkg.Context
 	AppConfig interface{}
 	ImageName string
+	Sbom      string
 }


### PR DESCRIPTION
When a user is using xeol.io with an API key, this allows them to send an SBOM alongside match data.