### PR TITLE
Add global + project policy matching

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -334,7 +334,7 @@ func startWorker(userInput string, failOnEolFound bool, eolMatchDate time.Time) 
 			}
 		}
 
-		failScan := policy.Evaluate(policies, allMatches)
+		failScan := policy.Evaluate(policies, allMatches, appConfig.ProjectName)
 
 		bus.Publish(partybus.Event{
 			Type:  event.EolScanningFinished,

--- a/internal/xeolio/request.go
+++ b/internal/xeolio/request.go
@@ -14,6 +14,7 @@ import (
 )
 
 type PolicyType string
+type PolicyScope string
 type CycleOperator string
 
 const (
@@ -22,18 +23,38 @@ const (
 
 	PolicyTypeEol PolicyType = "EOL"
 
+	PolicyScopeGlobal   PolicyScope = "global"
+	PolicyScopeProject  PolicyScope = "project"
+	PolicyScopeSoftware PolicyScope = "software"
+
 	CycleOperatorLessThan        CycleOperator = "LT"
 	CycleOperatorLessThanOrEqual CycleOperator = "LTE"
 	CycleOperatorEqual           CycleOperator = "EQ"
 )
 
 type Policy struct {
-	ID            string        `json:"id"`
-	PolicyType    PolicyType    `json:"policy_type"`
-	WarnDate      string        `json:"warn_date"`
-	DenyDate      string        `json:"deny_date"`
-	ProductName   string        `json:"product_name"`
-	Cycle         string        `json:"cycle"`
+	ID string `json:"id"`
+	// the policy scope can be one of: global, project, software
+	// global: the policy applies to all projects and software
+	// project: the policy applies to all software in a project
+	// software: the policy applies to a specific software
+	PolicyScope PolicyScope `json:"policy_scope"`
+	// the type of policy [eol]
+	PolicyType PolicyType `json:"policy_type"`
+	// the date which to start warning xeol scans
+	WarnDate string `json:"warn_date"`
+	// the date which to start failing xeol scans
+	DenyDate string `json:"deny_date"`
+	// the project name to match policy against. Valid when PolicyScope is 'project'
+	ProjectName string `json:"project_name"`
+	//
+	// the following fields are only used when PolicyScope is 'software'
+	//
+	// the product name to match policy against.
+	ProductName string `json:"product_name"`
+	// the cycle to match policy against.
+	Cycle string `json:"cycle"`
+	// the cycle operator to match policy against.
 	CycleOperator CycleOperator `json:"cycle_operator"`
 }
 

--- a/internal/xeolio/request.go
+++ b/internal/xeolio/request.go
@@ -46,16 +46,27 @@ type Policy struct {
 	// the date which to start failing xeol scans
 	DenyDate string `json:"deny_date"`
 	// the project name to match policy against. Valid when PolicyScope is 'project'
-	ProjectName string `json:"project_name"`
+	ProjectName string `json:"project_name,omitempty"`
 	//
 	// the following fields are only used when PolicyScope is 'software'
 	//
 	// the product name to match policy against.
-	ProductName string `json:"product_name"`
+	ProductName string `json:"product_name,omitempty"`
 	// the cycle to match policy against.
-	Cycle string `json:"cycle"`
+	Cycle string `json:"cycle,omitempty"`
 	// the cycle operator to match policy against.
-	CycleOperator CycleOperator `json:"cycle_operator"`
+	CycleOperator CycleOperator `json:"cycle_operator,omitempty"`
+}
+
+func (ps *PolicyScope) UnmarshalJSON(b []byte) error {
+	str := strings.Trim(string(b), "\"")
+	switch str {
+	case string(PolicyScopeGlobal), string(PolicyScopeProject), string(PolicyScopeSoftware):
+		*ps = PolicyScope(str)
+	default:
+		return fmt.Errorf("invalid PolicyScope %s", str)
+	}
+	return nil
 }
 
 func (pt *PolicyType) UnmarshalJSON(b []byte) error {
@@ -73,7 +84,7 @@ func (co *CycleOperator) UnmarshalJSON(b []byte) error {
 	case string(CycleOperatorLessThan), string(CycleOperatorLessThanOrEqual), string(CycleOperatorEqual):
 		*co = CycleOperator(str)
 	default:
-		return fmt.Errorf("invalid CycleOperator %s", str)
+		return nil
 	}
 	return nil
 }

--- a/xeol/policy/policy_test.go
+++ b/xeol/policy/policy_test.go
@@ -8,10 +8,10 @@ import (
 
 	syftPkg "github.com/anchore/syft/syft/pkg"
 	"github.com/google/uuid"
+
 	"github.com/xeol-io/xeol/internal/xeolio"
 	"github.com/xeol-io/xeol/xeol/eol"
 	"github.com/xeol-io/xeol/xeol/match"
-
 	"github.com/xeol-io/xeol/xeol/pkg"
 )
 


### PR DESCRIPTION
Adding more advanced policy evaluation:
- `Global`: applies to all software under a Xeol org
- `Project`: applies to a specific project
- `Software`: applies to a specific software+cycle