### PR TITLE
[feat] Dynamic policy dates

### DIFF
--- a/internal/xeolio/request.go
+++ b/internal/xeolio/request.go
@@ -42,9 +42,13 @@ type Policy struct {
 	// the type of policy [eol]
 	PolicyType PolicyType `json:"policy_type"`
 	// the date which to start warning xeol scans
-	WarnDate string `json:"warn_date"`
+	WarnDate string `json:"warn_date,omitempty"`
 	// the date which to start failing xeol scans
-	DenyDate string `json:"deny_date"`
+	DenyDate string `json:"deny_date,omitempty"`
+	// the days before eol to start warning xeol scans
+	WarnDays *int `json:"warn_days,omitempty"`
+	// the days before eol to start failing xeol scans
+	DenyDays *int `json:"deny_days,omitempty"`
 	// the project name to match policy against. Valid when PolicyScope is 'project'
 	ProjectName string `json:"project_name,omitempty"`
 	//

--- a/xeol/policy/policy.go
+++ b/xeol/policy/policy.go
@@ -171,6 +171,7 @@ func evaluateMatches(policies []xeolio.Policy, matches match.Matches, projectNam
 	sort.Stable(ByPolicyScope(policies))
 
 	for _, policy := range policies {
+		policyCopy := policy
 		for _, match := range matches.Sorted() {
 			if evaluatedMatches[match.Cycle.ProductName] {
 				continue
@@ -188,13 +189,13 @@ func evaluateMatches(policies []xeolio.Policy, matches match.Matches, projectNam
 			}
 
 			// deny policy takes precedence over warn policy, so order is important here
-			if denyMatch(&policy, match) {
-				results = append(results, createEvaluationResult(policy, match, PolicyTypeDeny))
+			if denyMatch(&policyCopy, match) {
+				results = append(results, createEvaluationResult(policyCopy, match, PolicyTypeDeny))
 				evaluatedMatches[match.Cycle.ProductName] = true
 				continue
 			}
-			if warnMatch(&policy, match) {
-				results = append(results, createEvaluationResult(policy, match, PolicyTypeWarn))
+			if warnMatch(&policyCopy, match) {
+				results = append(results, createEvaluationResult(policyCopy, match, PolicyTypeWarn))
 				evaluatedMatches[match.Cycle.ProductName] = true
 			}
 		}

--- a/xeol/policy/policy.go
+++ b/xeol/policy/policy.go
@@ -80,27 +80,68 @@ func cycleOperatorMatch(m match.Match, policy xeolio.Policy) bool {
 	}
 }
 
-func warnMatch(policy xeolio.Policy) bool {
-	warnDate, err := time.Parse(DateLayout, policy.WarnDate)
-	if err != nil {
-		log.Debugf("Invalid policy warn date: %s", policy.WarnDate)
+func warnMatch(policy *xeolio.Policy, match match.Match) bool {
+	var warnDate time.Time
+
+	if policy.WarnDate != "" {
+		var err error
+		warnDate, err = time.Parse(DateLayout, policy.WarnDate)
+		if err != nil {
+			log.Errorf("invalid policy warn date: %s", policy.WarnDate)
+			return false
+		}
+	}
+
+	if policy.WarnDays != nil {
+		eolDate, err := time.Parse(DateLayout, match.Cycle.Eol)
+		if err != nil {
+			log.Errorf("invalid eol date: %s, %s", match.Cycle.Eol, err)
+			return false
+		}
+		warnDate = eolDate.Add(time.Duration(*policy.WarnDays*-1) * time.Hour * 24)
+	}
+
+	if warnDate.IsZero() {
 		return false
 	}
+
 	if timeNow().After(warnDate) {
 		return true
 	}
+
 	return false
 }
 
-func denyMatch(policy xeolio.Policy) bool {
-	denyDate, err := time.Parse(DateLayout, policy.DenyDate)
-	if err != nil {
-		log.Debugf("Invalid policy deny date: %s", policy.DenyDate)
+func denyMatch(policy *xeolio.Policy, match match.Match) bool {
+	var denyDate time.Time
+
+	if policy.DenyDate != "" {
+		var err error
+		denyDate, err = time.Parse(DateLayout, policy.DenyDate)
+		if err != nil {
+			log.Errorf("invalid policy deny date: %s", policy.DenyDate)
+			return false
+		}
+	}
+
+	if policy.DenyDays != nil {
+		eolDate, err := time.Parse(DateLayout, match.Cycle.Eol)
+		if err != nil {
+			log.Errorf("invalid eol date: %s, %s", match.Cycle.Eol, err)
+			return false
+		}
+		denyDate = eolDate.Add(time.Duration(*policy.DenyDays*-1) * time.Hour * 24)
+		policy.DenyDate = denyDate.Format(DateLayout)
+	}
+
+	if denyDate.IsZero() {
 		return false
 	}
+
 	if timeNow().After(denyDate) {
 		return true
 	}
+
 	return false
 }
 
@@ -147,12 +188,12 @@ func evaluateMatches(policies []xeolio.Policy, matches match.Matches, projectNam
 			}
 
 			// deny policy takes precedence over warn policy, so order is important here
-			if denyMatch(policy) {
+			if denyMatch(&policy, match) {
 				results = append(results, createEvaluationResult(policy, match, PolicyTypeDeny))
 				evaluatedMatches[match.Cycle.ProductName] = true
 				continue
 			}
-			if warnMatch(policy) {
+			if warnMatch(&policy, match) {
 				results = append(results, createEvaluationResult(policy, match, PolicyTypeWarn))
 				evaluatedMatches[match.Cycle.ProductName] = true
 			}

--- a/xeol/policy/policy_test.go
+++ b/xeol/policy/policy_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/xeol-io/xeol/xeol/pkg"
 )
 
+func Int(value int) *int {
+	return &value
+}
+
 func TestEvaluate(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -497,6 +501,105 @@ func TestEvaluate(t *testing.T) {
 					ProductName: "foo",
 					Cycle:       "1.3",
 					FailDate:    "2021-02-29",
+				},
+			},
+		},
+		{
+			name: "test sliding global policy [deny]",
+			policy: []xeolio.Policy{
+				{
+					PolicyScope: xeolio.PolicyScopeGlobal,
+					PolicyType:  xeolio.PolicyTypeEol,
+					WarnDays:    Int(60),
+					DenyDays:    Int(30),
+				},
+			},
+			matches: []match.Match{
+				{
+					Cycle: eol.Cycle{
+						ProductName:  "foo",
+						ReleaseCycle: "1.3",
+						Eol:          "2021-02-28",
+					},
+					Package: pkg.Package{
+						ID:      pkg.ID(uuid.NewString()),
+						Name:    "foo",
+						Version: "1.3.0",
+						Type:    syftPkg.RpmPkg,
+					},
+				},
+			},
+			want: []EvaluationResult{
+				{
+					Type:        PolicyTypeDeny,
+					ProductName: "foo",
+					Cycle:       "1.3",
+				},
+			},
+		},
+		{
+			name: "test sliding global policy [warn]",
+			policy: []xeolio.Policy{
+				{
+					PolicyScope: xeolio.PolicyScopeGlobal,
+					PolicyType:  xeolio.PolicyTypeEol,
+					WarnDays:    Int(60),
+					DenyDays:    Int(30),
+				},
+			},
+			matches: []match.Match{
+				{
+					Cycle: eol.Cycle{
+						ProductName:  "foo",
+						ReleaseCycle: "1.3",
+						Eol:          "2021-03-28",
+					},
+					Package: pkg.Package{
+						ID:      pkg.ID(uuid.NewString()),
+						Name:    "foo",
+						Version: "1.3.0",
+						Type:    syftPkg.RpmPkg,
+					},
+				},
+			},
+			want: []EvaluationResult{
+				{
+					Type:        PolicyTypeWarn,
+					ProductName: "foo",
+					Cycle:       "1.3",
+					FailDate:    "2021-02-26",
+				},
+			},
+		},
+		{
+			name: "test sliding global policy [deny, no warn]",
+			policy: []xeolio.Policy{
+				{
+					PolicyScope: xeolio.PolicyScopeGlobal,
+					PolicyType:  xeolio.PolicyTypeEol,
+					DenyDays:    Int(30),
+				},
+			},
+			matches: []match.Match{
+				{
+					Cycle: eol.Cycle{
+						ProductName:  "foo",
+						ReleaseCycle: "1.3",
+						Eol:          "2021-02-28",
+					},
+					Package: pkg.Package{
+						ID:      pkg.ID(uuid.NewString()),
+						Name:    "foo",
+						Version: "1.3.0",
+						Type:    syftPkg.RpmPkg,
+					},
+				},
+			},
+			want: []EvaluationResult{
+				{
+					Type:        PolicyTypeDeny,
+					ProductName: "foo",
+					Cycle:       "1.3",
 				},
 			},
 		},


### PR DESCRIPTION
Adding policy evaluation for `denyDays` and `warnDays`

this allows selecting a global or project policy to warn X days before or after an EOL match result. 

Examples:
- `DenyDays: -60` will deny a scan for any software 60 days after its EOL date.
- `DenyDays: 60` will deny a scan for any software 60 days before its EOL date. 