### PR TITLE
Add product permalink to cycle + json output

### DIFF
--- a/xeol/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
+++ b/xeol/presenter/json/test-fixtures/snapshot/TestJsonDirsPresenter.golden
@@ -3,6 +3,7 @@
   {
    "Cycle": {
     "ProductName": "MongoDB Server",
+    "ProductPermalink": "",
     "ReleaseCycle": "2.8",
     "Eol": "true",
     "LatestRelease": "",
@@ -45,6 +46,7 @@
   {
    "Cycle": {
     "ProductName": "MongoDB Server",
+    "ProductPermalink": "",
     "ReleaseCycle": "3.2",
     "Eol": "2018-07-31",
     "LatestRelease": "",
@@ -94,6 +96,7 @@
   {
    "Cycle": {
     "ProductName": "Ubuntu",
+    "ProductPermalink": "",
     "ReleaseCycle": "16.04",
     "Eol": "2021-04-02",
     "LatestRelease": "",

--- a/xeol/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
+++ b/xeol/presenter/json/test-fixtures/snapshot/TestJsonImgsPresenter.golden
@@ -3,6 +3,7 @@
   {
    "Cycle": {
     "ProductName": "MongoDB Server",
+    "ProductPermalink": "",
     "ReleaseCycle": "2.8",
     "Eol": "true",
     "LatestRelease": "",
@@ -45,6 +46,7 @@
   {
    "Cycle": {
     "ProductName": "MongoDB Server",
+    "ProductPermalink": "",
     "ReleaseCycle": "3.2",
     "Eol": "2018-07-31",
     "LatestRelease": "",
@@ -94,6 +96,7 @@
   {
    "Cycle": {
     "ProductName": "Ubuntu",
+    "ProductPermalink": "",
     "ReleaseCycle": "16.04",
     "Eol": "2021-04-02",
     "LatestRelease": "",

--- a/xeol/presenter/models/cycle.go
+++ b/xeol/presenter/models/cycle.go
@@ -8,6 +8,7 @@ import (
 
 type Cycle struct {
 	ProductName       string
+	ProductPermalink  string
 	ReleaseCycle      string
 	Eol               string
 	LatestRelease     string
@@ -25,6 +26,7 @@ func NewCycle(c eol.Cycle) Cycle {
 
 	return Cycle{
 		ProductName:       c.ProductName,
+		ProductPermalink:  c.ProductPermalink,
 		ReleaseCycle:      c.ReleaseCycle,
 		Eol:               eol,
 		LatestRelease:     c.LatestRelease,


### PR DESCRIPTION
This adds a `Product Permalink` to JSON output so that users can quickly see more information about an EOL product.