### PR TITLE
handle EOL bool items in policy

### DIFF
--- a/xeol/policy/eol/eol_test.go
+++ b/xeol/policy/eol/eol_test.go
@@ -27,6 +27,43 @@ func TestEvaluate(t *testing.T) {
 		want    []types.EolEvaluationResult
 	}{
 		{
+			name: "policy with eol bool match",
+			policy: []Policy{
+				{
+					ProductName:   "foo",
+					Cycle:         "1.0.0",
+					PolicyScope:   PolicyScopeSoftware,
+					CycleOperator: CycleOperatorLessThan,
+					WarnDate:      "2021-01-01",
+					DenyDate:      "2021-01-01",
+				},
+			},
+			matches: []match.Match{
+				{
+					Cycle: eol.Cycle{
+						ProductName:  "foo",
+						ReleaseCycle: "1.0.0",
+						EolBool:      true,
+					},
+					Package: pkg.Package{
+						ID:      pkg.ID(uuid.NewString()),
+						Name:    "package-e",
+						Version: "2.0.0",
+						Type:    syftPkg.RpmPkg,
+					},
+				},
+			},
+			want: []types.EolEvaluationResult{
+				{
+					Action:      types.PolicyActionWarn, // eol bool is always a warn
+					Type:        types.PolicyTypeEol,
+					ProductName: "foo",
+					Cycle:       "1.0.0",
+					// fail date should be empty for eol bool
+				},
+			},
+		},
+		{
 			name: "policy with no matches",
 			policy: []Policy{
 				{


### PR DESCRIPTION
Unfortunately, for some EOL items, we do not know when they became deprecated. This is the case with certain packages sourced from NuGet. https://github.com/NuGet/Home/issues/12845

We have to handle these carefully in policy. We chose the softer policy around only warning items that are EOL bool. Blocking, even though policy says to do so would be very disruptive for engineers without any warning. 