### PR TITLE
Ingest directory scheme scans into xeol.io

### DIFF
--- a/internal/xeolio/request.go
+++ b/internal/xeolio/request.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	XeolAPIURL    = "https://api.xeol.io"
-	XeolEngineURL = "https://engine.xeol.io"
+	XeolAPIURL = "https://api.xeol.io"
 )
 
 type XeolClient struct {
@@ -77,5 +76,5 @@ func (x *XeolClient) SendEvent(payload report.XeolEventPayload) error {
 		return fmt.Errorf("error marshalling xeol.io API request: %v", err)
 	}
 
-	return x.makeRequest("PUT", XeolEngineURL, "v1/scan", bytes.NewBuffer(p), nil)
+	return x.makeRequest("PUT", XeolAPIURL, "v2/scan", bytes.NewBuffer(p), nil)
 }

--- a/internal/xeolio/source.go
+++ b/internal/xeolio/source.go
@@ -1,0 +1,76 @@
+package xeolio
+
+import (
+	"fmt"
+
+	"github.com/anchore/syft/syft/source"
+)
+
+type EventSource interface {
+	Serialize() map[string]interface{}
+}
+
+type DirectorySource struct {
+	ID     string
+	Type   string
+	Target string
+}
+
+func (s *DirectorySource) Serialize() map[string]interface{} {
+	return map[string]interface{}{
+		"ID":     s.ID,
+		"Type":   s.Type,
+		"Target": s.Target,
+	}
+}
+
+func NewDirectorySource(sbomSource source.Metadata) *DirectorySource {
+	return &DirectorySource{
+		ID:     sbomSource.ID,
+		Type:   string(sbomSource.Scheme),
+		Target: sbomSource.Path,
+	}
+}
+
+type ImageSource struct {
+	ID             string
+	Type           string
+	ImageName      string
+	ImageDigest    string
+	ManifestDigest string
+}
+
+func NewImageSource(sbomSource source.Metadata) *ImageSource {
+	return &ImageSource{
+		ID:             sbomSource.ID,
+		Type:           string(sbomSource.Scheme),
+		ImageName:      sbomSource.ImageMetadata.UserInput,
+		ImageDigest:    sbomSource.ImageMetadata.ID,
+		ManifestDigest: sbomSource.ImageMetadata.ManifestDigest,
+	}
+}
+
+func (s *ImageSource) Serialize() map[string]interface{} {
+	return map[string]interface{}{
+		"ID":             s.ID,
+		"Type":           s.Type,
+		"ImageName":      s.ImageName,
+		"ImageDigest":    s.ImageDigest,
+		"ManifestDigest": s.ManifestDigest,
+	}
+}
+
+func EventSourceScheme(sbomSource source.Metadata) source.Scheme {
+	return sbomSource.Scheme
+}
+
+func NewEventSource(sbomSource source.Metadata) (map[string]interface{}, error) {
+	if sbomSource.Scheme == source.DirectoryScheme {
+		return NewDirectorySource(sbomSource).Serialize(), nil
+	}
+	if sbomSource.Scheme == source.ImageScheme {
+		return NewImageSource(sbomSource).Serialize(), nil
+	}
+
+	return nil, fmt.Errorf("unsupported source type: %s", sbomSource.Scheme)
+}

--- a/xeol/report/model.go
+++ b/xeol/report/model.go
@@ -11,7 +11,6 @@ type XeolEventPayload struct {
 	Context       pkg.Context
 	AppConfig     interface{}
 	ImageVerified bool
-	ImageName     string
-	ImageDigest   string
+	EventSource   map[string]interface{}
 	Sbom          string
 }


### PR DESCRIPTION
Add support for directory scheme scans in xeol.io. 

This means that when a user uses `xeol ./mydir --api-key=xxxx` the scan will be ingested.