### PR TITLE
fix manifest warning output

### DIFF
--- a/internal/sigverifier/notary/manifest.go
+++ b/internal/sigverifier/notary/manifest.go
@@ -19,7 +19,7 @@ import (
 
 func resolveReferenceWithWarning(ctx context.Context, inputType inputType, reference string, sigRepo notationregistry.Repository, operation string) (ocispec.Descriptor, string, error) {
 	return resolveReference(ctx, inputType, reference, sigRepo, func(ref string, manifestDesc ocispec.Descriptor) {
-		fmt.Fprintf(os.Stderr, "Warning: Always %s the artifact using digest(@sha256:...) rather than a tag(:%s) because resolved digest may not point to the same signed artifact, as tags are mutable.\n", operation, ref)
+		log.Warnf("Warning: Always %s the artifact using digest(@sha256:...) rather than a tag(:%s) because resolved digest may not point to the same signed artifact, as tags are mutable.\n", operation, ref)
 	})
 }
 


### PR DESCRIPTION
This was printing a warn message that was not consistent with our logging package