### PR TITLE
add metadata in goreleaser snapshot

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,10 +24,10 @@ builds:
       -w
       -s
       -extldflags '-static'
-      -X github.com/xeol-io/xeol/internal/version.version={{.Version}}
-      -X github.com/xeol-io/xeol/internal/version.gitCommit={{.Commit}}
-      -X github.com/xeol-io/xeol/internal/version.buildDate={{.Date}}
-      -X github.com/xeol-io/xeol/internal/version.gitDescription={{.Summary}}
+      -X main.version={{.Version}}
+      -X main.gitCommit={{.Commit}}
+      -X main.buildDate={{.Date}}
+      -X main.gitDescription={{.Summary}}
 
   - id: darwin-build
     dir: ./cmd/xeol


### PR DESCRIPTION
this fixes a bug introduced in https://github.com/xeol-io/xeol/pull/180 which caused the version of Xeol to show [not provided]

before: 
```
xeol version
Application:         xeol
Version:             [not provided]
BuildDate:           [not provided]
GitCommit:           [not provided]
GitDescription:      [not provided]
Platform:            darwin/arm64
GoVersion:           go1.21.1
Compiler:            gc
Syft Version:        v0.91.0
Supported DB Schema: 1
```

