### PR TITLE
make `normalizeSemver` handle 4 component versions

### DIFF
--- a/xeol/search/purl.go
+++ b/xeol/search/purl.go
@@ -76,7 +76,7 @@ func ByDistroCpe(store eol.Provider, distro *linux.Release, eolMatchDate time.Ti
 func normalizeSemver(version string) string {
 	// For Ruby versions. Example: 2.5.3p105 -> 2.5.3
 	re := regexp.MustCompile(`^(\d+\.\d+\.\d+)p\d+`)
-	return re.ReplaceAllString(version, "$1")
+	version = re.ReplaceAllString(version, "$1")
 
 	// Handle 4-component versions.
 	// Example: 5.0.20.5194 -> 5.0.20

--- a/xeol/search/purl.go
+++ b/xeol/search/purl.go
@@ -77,6 +77,12 @@ func normalizeSemver(version string) string {
 	// For Ruby versions. Example: 2.5.3p105 -> 2.5.3
 	re := regexp.MustCompile(`^(\d+\.\d+\.\d+)p\d+`)
 	return re.ReplaceAllString(version, "$1")
+
+	// Handle 4-component versions.
+	// Example: 5.0.20.5194 -> 5.0.20
+	// Example: 2.0.4.RELEASE -> 2.0.4
+	fourCompRe := regexp.MustCompile(`^(\d+\.\d+\.\d+)\.\w+`)
+	return fourCompRe.ReplaceAllString(version, "$1")
 }
 
 func versionLength(version string) int {

--- a/xeol/search/purl_test.go
+++ b/xeol/search/purl_test.go
@@ -15,6 +15,14 @@ func TestNormalizeSemver(t *testing.T) {
 		expected string
 	}{
 		{
+			version:  "2.0.4.RELEASE",
+			expected: "2.0.4",
+		},
+		{
+			version:  "5.0.20.51904",
+			expected: "5.0.20",
+		},
+		{
 			version:  "1.2.3",
 			expected: "1.2.3",
 		},


### PR DESCRIPTION
needed for https://github.com/xeol-io/xeol/issues/197

springboot PURL versions always come in this form: `1.0.0.RELEASE`