### PR TITLE
Revert "Update Syft to v0.92.0 (#200)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4
 	github.com/anchore/packageurl-go v0.1.1-0.20230104203445-02e0a6721501
 	github.com/anchore/stereoscope v0.0.0-20230919183137-5841b53a0375
-	github.com/anchore/syft v0.92.0
+	github.com/anchore/syft v0.91.0
 	github.com/bmatcuk/doublestar/v2 v2.0.4
 	github.com/charmbracelet/bubbletea v0.24.2
 	github.com/charmbracelet/lipgloss v0.8.0


### PR DESCRIPTION
Reverting the upgrade from syft 0.91 to 0.91 since we're hardcoded at 0.91 with https://github.com/noqcks/syft for the foreseeable future

This reverts commit 55f96289f1f308fccc6848e3b3738319c5c30222.