### PR TITLE
update lookahead default value

### DIFF
--- a/cmd/xeol/cli/options/xeol.go
+++ b/cmd/xeol/cli/options/xeol.go
@@ -41,11 +41,18 @@ var _ interface {
 } = (*Xeol)(nil)
 
 func DefaultXeol(id clio.Identification) *Xeol {
+	project, commit := getDefaultProjectNameAndCommit()
+
 	config := &Xeol{
 		Search:            defaultSearch(source.SquashedScope),
 		DB:                DefaultDatabase(id),
 		Match:             defaultMatchConfig(),
 		CheckForAppUpdate: true,
+		Lookahead:         "30d",
+		FailOnEolFound:    false,
+		ProjectName:       project,
+		CommitHash:        commit,
+		ImagePath:         "Dockerfile",
 	}
 	return config
 }
@@ -142,16 +149,6 @@ func (o *Xeol) parseLookaheadOption() (err error) {
 	return nil
 }
 
-func (o *Xeol) loadDefaltValues() {
-	project, commit := getDefaultProjectNameAndCommit()
-	o.FailOnEolFound = false
-	o.Lookahead = "30d"
-	o.ProjectName = project
-	o.CommitHash = commit
-	o.ImagePath = "Dockerfile"
-}
-
 func (o *Xeol) PostLoad() error {
-	o.loadDefaltValues()
 	return o.parseLookaheadOption()
 }


### PR DESCRIPTION
reported in #228, setting a lookahead was not working, this was due to incorrect defaults in clio, the lookahead was always overwritten to be `30d`