### PR TITLE
handle tilde in version strings

### DIFF
--- a/xeol/search/purl.go
+++ b/xeol/search/purl.go
@@ -82,7 +82,12 @@ func normalizeSemver(version string) string {
 	// Example: 5.0.20.5194 -> 5.0.20
 	// Example: 2.0.4.RELEASE -> 2.0.4
 	fourCompRe := regexp.MustCompile(`^(\d+\.\d+\.\d+)\.\w+`)
-	return fourCompRe.ReplaceAllString(version, "$1")
+	version = fourCompRe.ReplaceAllString(version, "$1")
+
+	// // Handle packages with tilde (~) characters
+	// // Example: 1.23.3-1~bullseye
+	tildeRe := regexp.MustCompile(`^(\d+\.\d+\.\d+)-\d+~\w+`)
+	return tildeRe.ReplaceAllString(version, "$1")
 }
 
 func versionLength(version string) int {

--- a/xeol/search/purl.go
+++ b/xeol/search/purl.go
@@ -84,8 +84,8 @@ func normalizeSemver(version string) string {
 	fourCompRe := regexp.MustCompile(`^(\d+\.\d+\.\d+)\.\w+`)
 	version = fourCompRe.ReplaceAllString(version, "$1")
 
-	// // Handle packages with tilde (~) characters
-	// // Example: 1.23.3-1~bullseye
+	// Handle packages with tilde (~) characters
+	// Example: 1.23.3-1~bullseye
 	tildeRe := regexp.MustCompile(`^(\d+\.\d+\.\d+)-\d+~\w+`)
 	return tildeRe.ReplaceAllString(version, "$1")
 }

--- a/xeol/search/purl_test.go
+++ b/xeol/search/purl_test.go
@@ -15,6 +15,10 @@ func TestNormalizeSemver(t *testing.T) {
 		expected string
 	}{
 		{
+			version:  "1.23.3-1~bullseye",
+			expected: "1.23.3",
+		},
+		{
 			version:  "2.0.4.RELEASE",
 			expected: "2.0.4",
 		},


### PR DESCRIPTION
Fixes https://github.com/xeol-io/xeol/issues/269

Scanning nginx:1.23.3 included the nginx version string `1.23.3-1~bullseye`, which was preventing matching to an nginx version in the database.