### PR TITLE
Update slsa-github-generator to v2.10.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,7 +137,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
     with:
       base64-subjects: "${{ needs.release.outputs.hashes }}"
       upload-assets: true # upload to a new release


### PR DESCRIPTION
https://github.com/slsa-framework/slsa-github-generator

For some reason we get `Error: Process completed with exit code 27.` on the current versions of the action. 

It seems to have suddenly appeared since this was working before with the same version of the action. I wonder if it's due to breaking contract with the client (gh actions) and the server (sigstore).

before I go and create an issue on their github repo, let's try bump the version to see if it fixes it.