### PR TITLE
Simplify apk commands and prevent Alpine cache in Dockerfile.dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,8 +9,7 @@ COPY go.mod go.sum Makefile /xeol/
 COPY .github .github
 
 RUN docker-entrypoint.sh sh && \
-    apk update && \
-    apk add make curl build-base bash ncurses openssl && \
+    apk add --update make curl build-base bash ncurses openssl && \
     curl -OL https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
     tar -C /usr/local -xf go${GO_VERSION}.linux-amd64.tar.gz && \
     go install github.com/go-delve/delve/cmd/dlv@d9d8f4ad8c9b0c9cc74b100fb1afb109f89dd493 && \


### PR DESCRIPTION
Replace `apk update && apk add` with `apk add --update` to combine two operations into one and prevent temporary Alpine package index files (`/var/cache/apk/*`) from being left in the image.
