### PR TITLE
feat: Add SARIF format reporting for CI/CD integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -212,6 +212,7 @@ require (
 	github.com/nwaples/rardecode v1.1.2 // indirect
 	github.com/opencontainers/runtime-spec v1.1.0 // indirect
 	github.com/opencontainers/selinux v1.11.0 // indirect
+	github.com/owenrumney/go-sarif/v2 v2.3.3 // indirect
 	github.com/pborman/indent v1.2.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -287,6 +287,7 @@ github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHG
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46 h1:vmXNl+HDfqqXgr0uY1UgK1GAhps8nbAAtqHNBcgyf+4=
 github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46/go.mod h1:olhPNdiiAAMiSujemd1O/sc6GcyePr23f/6uGKtthNg=
 github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492 h1:rcEG5HI490FF0a7zuvxOxen52ddygCfNVjP0XOCMl+M=
@@ -907,6 +908,10 @@ github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaL
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 github.com/oras-project/oras-credentials-go v0.3.1 h1:sfGqZ8sjPifEaOtjHOQTPr8D+Tql4bpw58Dd9wjmm9w=
 github.com/oras-project/oras-credentials-go v0.3.1/go.mod h1:fFCebDQo0Do+gnM96uV9YUnRay0pwuRQupypvofsp4s=
+github.com/owenrumney/go-sarif v1.1.1 h1:QNObu6YX1igyFKhdzd7vgzmw7XsWN3/6NMGuDzBgXmE=
+github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
+github.com/owenrumney/go-sarif/v2 v2.3.3 h1:ubWDJcF5i3L/EIOER+ZyQ03IfplbSU1BLOE26uKQIIU=
+github.com/owenrumney/go-sarif/v2 v2.3.3/go.mod h1:MSqMMx9WqlBSY7pXoOZWgEsVB4FDNfhcaXDA1j6Sr+w=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/indent v1.2.1 h1:lFiviAbISHv3Rf0jcuh489bi06hj98JsVMtIDZQb9yM=
@@ -1091,6 +1096,8 @@ github.com/veraison/go-cose v1.3.0 h1:2/H5w8kdSpQJyVtIhx8gmwPJ2uSz1PkyWFx0idbd7r
 github.com/veraison/go-cose v1.3.0/go.mod h1:df09OV91aHoQWLmy1KsDdYiagtXgyAwAl8vFeFn1gMc=
 github.com/vifraa/gopom v1.0.0 h1:L9XlKbyvid8PAIK8nr0lihMApJQg/12OBvMA28BcWh0=
 github.com/vifraa/gopom v1.0.0/go.mod h1:oPa1dcrGrtlO37WPDBm5SqHAT+wTgF8An1Q71Z6Vv4o=
+github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
+github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/wagoodman/go-partybus v0.0.0-20230516145632-8ccac152c651 h1:jIVmlAFIqV3d+DOxazTR9v+zgj8+VYuQBzPgBZvWBHA=
 github.com/wagoodman/go-partybus v0.0.0-20230516145632-8ccac152c651/go.mod h1:b26F2tHLqaoRQf8DywqzVaV1MQ9yvjb0OMcNl7Nxu20=
 github.com/wagoodman/go-presenter v0.0.0-20211015174752-f9c01afc824b h1:uWNQ0khA6RdFzODOMwKo9XXu7fuewnnkHykUtuKru8s=
@@ -1117,6 +1124,7 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 go.etcd.io/etcd/api/v3 v3.5.1/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -8,6 +8,7 @@ const (
 	UnknownFormat Format = "unknown"
 	JSONFormat    Format = "json"
 	TableFormat   Format = "table"
+	SarifFormat   Format = "sarif"
 )
 
 // Format is a dedicated type to represent a specific kind of presenter output format.
@@ -26,6 +27,8 @@ func Parse(userInput string) Format {
 		return JSONFormat
 	case strings.ToLower(TableFormat.String()):
 		return TableFormat
+	case strings.ToLower(SarifFormat.String()):
+		return SarifFormat
 	default:
 		return UnknownFormat
 	}
@@ -35,4 +38,5 @@ func Parse(userInput string) Format {
 var AvailableFormats = []Format{
 	JSONFormat,
 	TableFormat,
+	SarifFormat,
 }

--- a/internal/format/presenter.go
+++ b/internal/format/presenter.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/xeol-io/xeol/xeol/presenter/json"
 	"github.com/xeol-io/xeol/xeol/presenter/models"
+	"github.com/xeol-io/xeol/xeol/presenter/sarif"
 	"github.com/xeol-io/xeol/xeol/presenter/table"
 )
 
@@ -15,6 +16,8 @@ func GetPresenter(format Format, pb models.PresenterConfig) presenter.Presenter 
 		return json.NewPresenter(pb)
 	case TableFormat:
 		return table.NewPresenter(pb)
+	case SarifFormat:
+		return sarif.NewPresenter(pb)
 	default:
 		return nil
 	}

--- a/xeol/presenter/format.go
+++ b/xeol/presenter/format.go
@@ -8,6 +8,7 @@ const (
 	unknownFormat format = "unknown"
 	jsonFormat    format = "json"
 	tableFormat   format = "table"
+	sarifFormat   format = "sarif"
 )
 
 // format is a dedicated type to represent a specific kind of presenter output format.
@@ -26,6 +27,8 @@ func parse(userInput string) format {
 		return jsonFormat
 	case strings.ToLower(tableFormat.String()):
 		return tableFormat
+	case strings.ToLower(sarifFormat.String()):
+		return sarifFormat
 	default:
 		return unknownFormat
 	}
@@ -35,4 +38,5 @@ func parse(userInput string) format {
 var AvailableFormats = []format{
 	jsonFormat,
 	tableFormat,
+	sarifFormat,
 }

--- a/xeol/presenter/presenter.go
+++ b/xeol/presenter/presenter.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/xeol-io/xeol/xeol/presenter/json"
 	"github.com/xeol-io/xeol/xeol/presenter/models"
+	"github.com/xeol-io/xeol/xeol/presenter/sarif"
 	"github.com/xeol-io/xeol/xeol/presenter/table"
 )
 
@@ -19,6 +20,8 @@ func GetPresenter(c Config, pb models.PresenterConfig) Presenter {
 		return json.NewPresenter(pb)
 	case tableFormat:
 		return table.NewPresenter(pb)
+	case sarifFormat:
+		return sarif.NewPresenter(pb)
 	default:
 		return nil
 	}

--- a/xeol/presenter/sarif/presenter.go
+++ b/xeol/presenter/sarif/presenter.go
@@ -1,0 +1,91 @@
+package sarif
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/owenrumney/go-sarif/v2/sarif"
+	"github.com/xeol-io/xeol/internal"
+	"github.com/xeol-io/xeol/internal/version"
+	"github.com/xeol-io/xeol/xeol/match"
+	"github.com/xeol-io/xeol/xeol/pkg"
+	"github.com/xeol-io/xeol/xeol/presenter/models"
+)
+
+// Presenter is a generic struct for holding fields needed for reporting
+type Presenter struct {
+	matches   match.Matches
+	packages  []pkg.Package
+	context   pkg.Context
+	appConfig interface{}
+	dbStatus  interface{}
+}
+
+// NewPresenter is a *Presenter constructor
+func NewPresenter(pb models.PresenterConfig) *Presenter {
+	return &Presenter{
+		matches:   pb.Matches,
+		packages:  pb.Packages,
+		context:   pb.Context,
+		appConfig: pb.AppConfig,
+		dbStatus:  pb.DBStatus,
+	}
+}
+
+// Present creates a SARIF-based reporting
+func (pres *Presenter) Present(output io.Writer) error {
+	doc, err := models.NewDocument(pres.packages, pres.context, pres.matches, pres.appConfig, pres.dbStatus)
+	if err != nil {
+		return err
+	}
+
+	report, err := sarif.New(sarif.Version210)
+	if err != nil {
+		return err
+	}
+
+	run := sarif.NewRunWithInformationURI(internal.ApplicationName, "https://github.com/xeol-io/xeol")
+	run.Tool.Driver.WithVersion(version.FromBuild().Version)
+
+	for _, match := range doc.Matches {
+		ruleId := "EOL-PACKAGE"
+		message := fmt.Sprintf("Package %s version %s reached End-Of-Life on %s", match.Artifact.Name, match.Artifact.Version, match.Cycle.Eol)
+
+		run.AddRule(ruleId).
+			WithDescription(message).
+			WithHelpURI("https://github.com/xeol-io/xeol").
+			WithShortDescription(sarif.NewMultiformatMessageString(fmt.Sprintf("%s is EOL", match.Artifact.Name)))
+
+		result := sarif.NewRuleResult(ruleId).
+			WithMessage(sarif.NewMessage().WithText(message)).
+			WithLevel("warning")
+
+		for _, loc := range match.Artifact.Locations {
+			result.AddLocation(
+				sarif.NewLocationWithPhysicalLocation(
+					sarif.NewPhysicalLocation().
+						WithArtifactLocation(
+							sarif.NewSimpleArtifactLocation(loc.RealPath),
+						),
+				),
+			)
+		}
+
+		if len(match.Artifact.Locations) == 0 {
+			result.AddLocation(
+				sarif.NewLocationWithPhysicalLocation(
+					sarif.NewPhysicalLocation().
+						WithArtifactLocation(
+							sarif.NewSimpleArtifactLocation("image"),
+						),
+				),
+			)
+		}
+
+		run.AddResult(result)
+	}
+
+	report.AddRun(run)
+
+	return report.PrettyWrite(output)
+}


### PR DESCRIPTION
### Summary
This PR introduces support for the **SARIF (Static Analysis Results Interchange Format)** output format. 

By adding the `--output sarif` flag (or `sarif` to the `.xeol.yaml` config), users can now seamlessly integrate Xeol's End-of-Life dependency findings directly into modern CI/CD security dashboards, such as GitHub Advanced Security (GHAS) or GitLab Security.

### Changes Made
- Added a new `sarifFormat` to the internal format parsers and presenter options.
- Implemented a new `sarif.Presenter` utilizing the `github.com/owenrumney/go-sarif` library to ensure strict compliance with the SARIF v2.1.0 specification.
- Mapped Xeol's internal `match.Match` objects into standardized SARIF Rules and Results.
- Properly mapped Syft-discovered file coordinates (`Locations`) so that EOL findings highlight the exact file paths in the user's IDE or PR diffs.

### How to Test
1. Build the binary from this branch.
2. Run a scan against a local directory or image with the SARIF output flag:
   ```bash
   xeol dir:. -o sarif > xeol-results.sarif
   ```
3. Verify the `xeol-results.sarif` file is generated properly. 

Closes #599
